### PR TITLE
Correction for following errors while running:

### DIFF
--- a/scripts/ntripclient.py
+++ b/scripts/ntripclient.py
@@ -67,7 +67,7 @@ class ntripconnect(Thread):
             ''' This now separates individual RTCM messages and publishes each one on the same topic '''
             data = response.read(1)
             if len(data) != 0:
-                if data[0] == 211:
+                if data[0] == 211:                   
                     buf += data
                     data = response.read(2)
                     buf += data
@@ -91,13 +91,13 @@ class ntripconnect(Thread):
             else:
                 ''' If zero length data, close connection and reopen it '''
                 restart_count = restart_count + 1
-                rospy.logwarn("Zero length ", restart_count)
+                rospy.logwarn("Zero length ".format(restart_count))
                 connection.close()
                 connection = HTTPConnection(self.ntc.ntrip_server)
                 connection.request('GET', '/'+self.ntc.ntrip_stream, self.ntc.nmea_gga, headers)
                 response = connection.getresponse()
                 if response.status != 200: raise Exception("blah")
-                buf = ""
+                buf = bytes('', 'utf-8')
 
         connection.close()
 
@@ -128,4 +128,3 @@ class ntripclient:
 if __name__ == '__main__':
     c = ntripclient()
     c.run()
-


### PR DESCRIPTION
[WARN] [1653246727.777205]: Zero length 
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/pi/catkin_ws/src/ntrip_ros/scripts/ntripclient.py", line 72, in run
    buf += data
TypeError: can only concatenate str (not "bytes") to str

+++++++++++++++++++++++++

Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/pi/catkin_ws/src/ntrip_ros/scripts/ntripclient.py", line 94, in run
    rospy.logwarn("Zero length ", restart_count)
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/core.py", line 193, in logwarn
    _base_logger(msg, args, kwargs, level='warning')
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/core.py", line 183, in _base_logger
    logfunc(msg, *args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1458, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 954, in handle
    self.emit(record)
  File "/opt/ros/noetic/lib/python3/dist-packages/rosgraph/roslogging.py", line 246, in emit
    record_message = _defaultFormatter.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 668, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.8/logging/__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting